### PR TITLE
Improve readability of ssl config file

### DIFF
--- a/server-config-files/nginx_sslparams
+++ b/server-config-files/nginx_sslparams
@@ -17,10 +17,29 @@ server {
 	ssl_certificate PATH/to/certchain ;
 	ssl_certificate_key PATH/to/privkey ;
 
-	ssl_dhparam /etc/nginx/dhparam.pem; # generate with openssl dhparam -out PATH/TO/.pem 2048 OR 4096
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
 
+	# generate with openssl dhparam -out PATH/TO/.pem 2048
+	# Java8 isn't ready for 4096
+	ssl_dhparam /etc/nginx/dhparam.pem;
+
+	# Only use the modern TLS protocols
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+	# Use only the intersection of OpenSSL's HIGH ciphers
+	# with Ephemeral (elliptic curve) Diffie-Hellmann (Forward Secrecy)
+
+	ssl_ciphers "HIGH+EDH:HIGH+EECDH";
+	# prefer strong ciphers
+	ssl_prefer_server_ciphers on;
+
+	# Use OCSP stapling for increased client privacy
+	ssl_stapling on;
+
+	# Enable the SSL session cache for increased performance
+	ssl_session_cache builtin:1000 shared:SSL:10m;
+
+	# Tell clients never to load this site with unencrypted HTTP
+	add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains;' ;
 
 	location / {
 		...


### PR DESCRIPTION
Do not list ciphers manually (trust OpenSSL's curated HIGH list) and enforce the use of forward secrecy.

Also, file is now capped to a reasonable line length : )
