### PR TITLE
Sort cipher list by strength, preferring EECDH

### DIFF
--- a/server-config-files/nginx_sslparams
+++ b/server-config-files/nginx_sslparams
@@ -28,7 +28,7 @@ server {
 	# Use only the intersection of OpenSSL's HIGH ciphers
 	# with Ephemeral (elliptic curve) Diffie-Hellmann (Forward Secrecy)
 
-	ssl_ciphers "HIGH+EDH:HIGH+EECDH";
+	ssl_ciphers "HIGH+EECDH:HIGH+EDH:@STRENGTH";
 	# prefer strong ciphers
 	ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
Listing EECDH first is recommended at [1](https://community.qualys.com/blogs/securitylabs/2013/06/25/ssl-labs-deploying-forward-secrecy), since it is faster than EDH in session creation.

To avoid 128-bit EECDH being preferred to 256-bit EDH, afterwards sort the list by key strength.
