### PR TITLE
Move nginx configuration files into their own folder

### DIFF
--- a/server-config-files/etc/nginx/conf.d/ssl-certificate.conf
+++ b/server-config-files/etc/nginx/conf.d/ssl-certificate.conf
@@ -1,0 +1,3 @@
+# Adapt the file names
+ssl_certificate /etc/letsencrypt/live/HOSTNAME/fullchain.pem ;
+ssl_certificate_key /etc/letsencrypt/live/HOSTNAME/privkey.pem ;

--- a/server-config-files/etc/nginx/conf.d/ssl-configuration.conf
+++ b/server-config-files/etc/nginx/conf.d/ssl-configuration.conf
@@ -1,0 +1,34 @@
+# Drop this file as-is into /etc/nginx/conf.d
+
+# It will be included from /etc/nginx/nginx.conf,
+# into the default server context, affecting all ssl sites.
+#
+# The Strict-Transport-Security header will be ignored
+# by clients when sent on a plain HTTP.
+
+# generate with openssl dhparam -out dh2048.pem 2048
+# Not enough clients support 4096 yet.
+ssl_dhparam /etc/nginx/dh2048.pem;
+
+# If this is *NOT* set in /etc/nginx/nginx.conf
+# (Debian does this by default), set it here.
+#
+# Setting any of these options twice will
+# prevent server from starting!
+#
+# ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+# ssl_prefer_server_ciphers on;
+
+# Only allow high-grade forward secrecy ciphers,
+# prefer EECDH over EDH (faster) and otherwise
+# sort by key length in bits.
+ssl_ciphers "HIGH+EECDH:HIGH+EDH:@STRENGTH";
+
+# Use OCSP stapling for increased client privacy
+ssl_stapling on;
+
+# Enable the SSL session cache for increased performance
+ssl_session_cache builtin:1000 shared:SSL:10m;
+
+# Tell clients never to load this site with unencrypted HTTP
+add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains;' ;


### PR DESCRIPTION
1. Split the file that needs editing (certificate name) from the file that can be installed as-is
2. Update the `ssl-configuration.conf` file to _NOT_ include settings that are default on debian jessie (setting them twice would stop the server from starting)
